### PR TITLE
chore: Fixed Null Exception on JS Queue Thread in Expo 52

### DIFF
--- a/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
+++ b/native/android/src/main/java/com/nozbe/watermelondb/WMDatabaseBridge.java
@@ -248,7 +248,7 @@ public class WMDatabaseBridge extends ReactContextBaseJavaModule {
     public void invalidate() {
         // NOTE: See Database::install() for explanation
         super.invalidate();
-        reactContext.getCatalystInstance().getReactQueueConfiguration().getJSQueueThread().runOnQueue(() -> {
+        reactContext.runOnJSQueueThread(() -> {
             try {
                 Class<?> clazz = Class.forName("com.nozbe.watermelondb.jsi.WatermelonJSI");
                 Method method = clazz.getDeclaredMethod("onCatalystInstanceDestroy");


### PR DESCRIPTION
This change replaces getJSMessageQueueThread().runOnQueue() with runOnJSQueueThread() to improve readability and consistency with updated APIs.